### PR TITLE
Add Export stream optional `where` parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ This tap:
 - Transformations: De-nest `properties` to root-level, re-name properties with leading `$...` to `mp_reserved_...`, convert datetimes from project timezone to UTC.
 - Optional parameters
   - `export_events` to export only certain events
+  - `where` to filter events with a [segmentation expression](https://developer.mixpanel.com/reference/segmentation-expressions)
 
 **[engage](https://developer.mixpanel.com/docs/data-export-api#section-engage)**
 - Endpoint: https://mixpanel.com/api/2.0/engage

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name='pipelinewise-tap-mixpanel',
-      version='1.2.17',
+      version='1.2.18',
       description='Singer.io tap for extracting data from the mixpanel API - PipelineWise compatible',
       long_description=long_description,
       long_description_content_type='text/markdown',

--- a/tap_mixpanel/sync.py
+++ b/tap_mixpanel/sync.py
@@ -132,7 +132,8 @@ def sync_endpoint(client, #pylint: disable=too-many-branches
                   days_interval=None,
                   attribution_window=None,
                   export_events=None,
-                  denest_properties_flag=None):
+                  denest_properties_flag=None,
+                  where=None):
 
     # Get endpoint_config fields
     url = endpoint_config.get('url')
@@ -270,6 +271,10 @@ def sync_endpoint(client, #pylint: disable=too-many-branches
                     event = json.dumps([export_events] if isinstance(export_events, str) else export_events)
                     url_encoded = urllib.parse.quote(event)
                     querystring += f'&event={url_encoded}'
+
+                if stream_name == 'export' and where:
+                    url_encoded = urllib.parse.quote(where)
+                    querystring += f'&where={url_encoded}'
 
                 full_url = '{}/{}{}'.format(
                     url,
@@ -546,7 +551,8 @@ def sync(client, config, catalog, state, start_date):
             days_interval=int(config.get('date_window_size', '30')),
             attribution_window=int(config.get('attribution_window', '5')),
             export_events=config.get('export_events'),
-            denest_properties_flag=config.get('denest_properties', 'true')
+            denest_properties_flag=config.get('denest_properties', 'true'),
+            where=config.get('where')
         )
 
         update_currently_syncing(state, None)


### PR DESCRIPTION
## Problem

Enable the use of the `where` parameter of the [export API](https://developer.mixpanel.com/reference/raw-event-export) for the export stream.

## Proposed changes

Handle `where` as a export stream only optional configuration parameter, in the same way as `export_events` already is.


## Types of changes

What types of changes does your code introduce to PipelineWise?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions