### PR TITLE
Use `mp_processing_time_ms` as `export` stream replication bookmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ This tap:
 
 **[export](https://developer.mixpanel.com/docs/exporting-raw-data#section-export-api-reference)**
 - Endpoint: https://data.mixpanel.com/api/2.0/export
-- Primary key fields: `event`, `time`, `distinct_id`
+- Primary key fields: `event`, `time`, `distinct_id`, `mp_reserved_insert_id`
 - Replication strategy: INCREMENTAL (query filtered)
-  - Bookmark: `time`
-  - Bookmark query field: `from_date`, `to_date`
+  - Bookmark: `mp_processing_time_ms`
+  - Bookmark query field: `where` query on `mp_processing_time_ms` field and also required `from_date`, `to_date` on `time` field with `attribution_window`
 - Transformations: De-nest `properties` to root-level, re-name properties with leading `$...` to `mp_reserved_...`, convert datetimes from project timezone to UTC.
 - Optional parameters
   - `export_events` to export only certain events

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ This tap:
 - Primary key fields:  `distinct_id`
 - Replication strategy: FULL_TABLE (all records, every load)
 - Transformations: De-nest `$properties` to root-level, re-name properties with leading `$...` to `mp_reserved_...`.
+- Optional parameters
+  - `where` to filter with a [segmentation expression](https://developer.mixpanel.com/reference/segmentation-expressions)
 
 **[funnels](https://developer.mixpanel.com/docs/data-export-api#section-funnels)**
 - Endpoint 1 (name, id): https://data.mixpanel.com/api/2.0/export
@@ -55,6 +57,8 @@ This tap:
   - Bookmark: `date`
   - Bookmark query field: `from_date`, `to_date`
 - Transformations: Combine Endpoint 1 & 2 results, convert `date` keys to list to `results` list-array.
+- Optional parameters
+  - `where` to filter with a [segmentation expression](https://developer.mixpanel.com/reference/segmentation-expressions)
 
 **[revenue](https://developer.mixpanel.com/docs/data-export-api#section-hr-span-style-font-family-courier-revenue-span)**
 - Endpoint: https://mixpanel.com/api/2.0/engage/revenue
@@ -85,6 +89,8 @@ This tap:
   - `filter_by_cohort`: {cohort_id} (from `cohorts` endpoint)
 - Replication strategy: FULL_TABLE
 - Transformations: For each `cohort_id` in `cohorts` endpoint, query `engage` endpoint with `filter_by_cohort` parameter to create list of `distinct_id` for each `cohort_id`.
+- Optional parameters
+  - `where` to filter with a [segmentation expression](https://developer.mixpanel.com/reference/segmentation-expressions)
 
 
 ## Authentication
@@ -125,14 +131,21 @@ More details may be found in the [Mixpanel API Authentication](https://developer
         "user_agent": "tap-mixpanel <api_user_email@your_company.com>"
     }
     ```
-    
+
     If you want to export only certain events from the [Raw export API](https://developer.mixpanel.com/reference/export)
     then add `export_events` option to the `config.json` and list the required event names:
-    
+
     ```bash
    "export_events": ["event_one", "event_two"]
    ```
-    
+
+    If you want to filter the export using an [segmentation expression](https://developer.mixpanel.com/reference/segmentation-expressions)
+    for supported stream (`export`, `engage`, `funnels` & `cohort_members`) then add `where` option to the `config.json` with the expression:
+
+    ```bash
+   "where": "defined(properties[\\"property_one\\"])"
+   ```
+
     Optionally, also create a `state.json` file. `currently_syncing` is an optional attribute used for identifying the last object to be synced in case the job is interrupted mid-stream. The next run would begin where the last job left off.
 
     ```json
@@ -160,7 +173,7 @@ More details may be found in the [Mixpanel API Authentication](https://developer
     ```bash
     > tap-mixpanel --config tap_config.json --catalog catalog.json
     ```
-   
+
     Messages are written to standard output following the Singer specification.
     The resultant stream of JSON data can be consumed by a Singer target.
     To load to json files to verify outputs:

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name='pipelinewise-tap-mixpanel',
-      version='1.2.18',
+      version='1.3.0',
       description='Singer.io tap for extracting data from the mixpanel API - PipelineWise compatible',
       long_description=long_description,
       long_description_content_type='text/markdown',

--- a/tap_mixpanel/client.py
+++ b/tap_mixpanel/client.py
@@ -67,7 +67,7 @@ def get_exception_for_error_code(error_code):
 
 def raise_for_error(response):
     if response.status_code != 400:
-        LOGGER.warn('STATUS {}: {}, REASON: {}'.format(response.status_code,
+        LOGGER.warning('STATUS {}: {}, REASON: {}'.format(response.status_code,
             response.text, response.reason))
 
     try:

--- a/tap_mixpanel/schemas/export.json
+++ b/tap_mixpanel/schemas/export.json
@@ -15,6 +15,10 @@
       "type": ["null", "string"],
       "format": "date-time"
     },
+    "mp_processing_time_ms": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
     "properties": {
       "type": ["null", "object"]
     }

--- a/tap_mixpanel/streams.py
+++ b/tap_mixpanel/streams.py
@@ -9,7 +9,10 @@
 #        and setting the state
 #   params: Query, sort, and other endpoint specific parameters; default = {}
 #   data_key: JSON element containing the results list for the endpoint
-#   bookmark_query_field_from/to: From date-time field used for filtering the query
+#   bookmark_query_field_from/to: Project timezone YYYY-MM-DD date format fields used for filtering
+#       the query, with attribution window
+#   bookmark_where_query_field: Milliseconds since UTC field used for filtering in the where query,
+#       if where_filter is supported, without attribution window
 #   api_method: GET or POST
 #   parent_path, parent_id_field: Used for listing parent IDs and looping through each
 #   date_dictionary: True or False, to transform date keys to list-array
@@ -24,9 +27,10 @@ STREAMS = {
         'api_method': 'GET',
         'key_properties': ['event', 'time', 'distinct_id', 'mp_reserved_insert_id'],
         'replication_method': 'INCREMENTAL',
-        'replication_keys': ['time'],
+        'replication_keys': ['mp_processing_time_ms'],
         'bookmark_query_field_from': 'from_date',
         'bookmark_query_field_to': 'to_date',
+        'bookmark_where_query_field': 'mp_processing_time_ms',
         'date_dictionary': False,
         'pagination': False,
         'where_filter': True,

--- a/tap_mixpanel/streams.py
+++ b/tap_mixpanel/streams.py
@@ -21,7 +21,7 @@ STREAMS = {
         'path': 'export',
         'data_key': 'results',
         'api_method': 'GET',
-        'key_properties': ['mp_reserved_insert_id'],
+        'key_properties': ['event', 'time', 'distinct_id', 'mp_reserved_insert_id'],
         'replication_method': 'INCREMENTAL',
         'replication_keys': ['time'],
         'bookmark_query_field_from': 'from_date',

--- a/tap_mixpanel/streams.py
+++ b/tap_mixpanel/streams.py
@@ -14,6 +14,7 @@
 #   parent_path, parent_id_field: Used for listing parent IDs and looping through each
 #   date_dictionary: True or False, to transform date keys to list-array
 #   pagination: True or False, if endpoint supports pagination looping
+#   where_filter: True or False, if endpoint supports a where filter Segmentation Expression
 
 STREAMS = {
     'export': {
@@ -28,6 +29,7 @@ STREAMS = {
         'bookmark_query_field_to': 'to_date',
         'date_dictionary': False,
         'pagination': False,
+        'where_filter': True,
         'params': {}
     },
 
@@ -40,6 +42,7 @@ STREAMS = {
         'replication_method': 'FULL_TABLE',
         'date_dictionary': False,
         'pagination': True,
+        'where_filter': True,
         'params': {}
     },
 
@@ -57,6 +60,7 @@ STREAMS = {
         'bookmark_query_field_to': 'to_date',
         'date_dictionary': True,
         'pagination': False,
+        'where_filter': True,
         'params': {
             'funnel_id': '[parent_id]',
             'unit': 'day'
@@ -72,6 +76,7 @@ STREAMS = {
         'replication_method': 'FULL_TABLE',
         'date_dictionary': False,
         'pagination': False,
+        'where_filter': False,
         'params': {}
     },
 
@@ -86,6 +91,7 @@ STREAMS = {
         'replication_method': 'FULL_TABLE',
         'date_dictionary': False,
         'pagination': True,
+        'where_filter': True,
         'params': {
             'filter_by_cohort': '{"id": [parent_id]}'
         }
@@ -103,6 +109,7 @@ STREAMS = {
         'bookmark_query_field_to': 'to_date',
         'date_dictionary': True,
         'pagination': False,
+        'where_filter': False,
         'params': {
             'unit': 'day'
         }
@@ -119,6 +126,7 @@ STREAMS = {
         'bookmark_query_field_to': 'to_date',
         'date_dictionary': False,
         'pagination': False,
+        'where_filter': False,
         'params': {}
     }
 

--- a/tap_mixpanel/sync.py
+++ b/tap_mixpanel/sync.py
@@ -147,6 +147,7 @@ def sync_endpoint(client, #pylint: disable=too-many-branches
     id_fields = endpoint_config.get('key_properties')
     date_dictionary = endpoint_config.get('date_dictionary', False)
     pagination = endpoint_config.get('pagination', False)
+    where_filter_supported = endpoint_config.get('where_filter', False)
 
     # Get the latest bookmark for the stream and set the last_integer/datetime
     last_datetime = None
@@ -267,7 +268,7 @@ def sync_endpoint(client, #pylint: disable=too-many-branches
                     url_encoded = urllib.parse.quote(event)
                     params['event'] = url_encoded
 
-                if stream_name == 'export' and where:
+                if where_filter_supported and where:
                     params['where'] = urllib.parse.quote(where)
 
                 # querystring: Squash query params into string and replace [parent_id]

--- a/tap_mixpanel/sync.py
+++ b/tap_mixpanel/sync.py
@@ -184,20 +184,23 @@ def sync_endpoint(client, #pylint: disable=too-many-branches
 
         last_dttm = strptime_to_utc(last_datetime)
         delta_days = (now_datetime - last_dttm).days
-        # When `where` query is used attribution window is applied to all date windows inside loop
+
+        # With `where` query, attribution window is instead applied to all date windows inside loop
         if delta_days <= attribution_window and not bookmark_where_query_field:
             delta_days = attribution_window
             LOGGER.info("Start bookmark less than {} day attribution window.".format(
                 attribution_window))
+            start_window = now_datetime - timedelta(days=delta_days)
         elif delta_days >= 365:
             delta_days = 365
             LOGGER.warning("WARNING: Start date or bookmark greater than 1 year maxiumum.")
             LOGGER.warning("WARNING: Setting bookmark start to 1 year ago.")
+            start_window = now_datetime - timedelta(days=delta_days)
+        else:
+            start_window = last_dttm
 
-        start_window = now_datetime - timedelta(days=delta_days)
         end_window = start_window + timedelta(days=days_interval)
         end_window = min(end_window, now_datetime)
-
     else:
         start_window = strptime_to_utc(last_datetime)
         end_window = now_datetime

--- a/tap_mixpanel/sync.py
+++ b/tap_mixpanel/sync.py
@@ -262,19 +262,18 @@ def sync_endpoint(client, #pylint: disable=too-many-branches
                     params['session_id'] = session_id
                     params['page'] = page
 
-                # querystring: Squash query params into string and replace [parent_id]
-                querystring = '&'.join(['%s=%s' % (key, value) for (key, value) \
-                    in params.items()]).replace(
-                        '[parent_id]', str(parent_id))
-
                 if stream_name == 'export' and export_events:
                     event = json.dumps([export_events] if isinstance(export_events, str) else export_events)
                     url_encoded = urllib.parse.quote(event)
-                    querystring += f'&event={url_encoded}'
+                    params['event'] = url_encoded
 
                 if stream_name == 'export' and where:
-                    url_encoded = urllib.parse.quote(where)
-                    querystring += f'&where={url_encoded}'
+                    params['where'] = urllib.parse.quote(where)
+
+                # querystring: Squash query params into string and replace [parent_id]
+                querystring = '&'.join([f'{key}={value}' for (key, value) \
+                    in params.items()]).replace(
+                        '[parent_id]', str(parent_id))
 
                 full_url = '{}/{}{}'.format(
                     url,

--- a/tap_mixpanel/transform.py
+++ b/tap_mixpanel/transform.py
@@ -2,6 +2,7 @@ import datetime
 import pytz
 import singer
 from singer.utils import strftime
+from singer import _transform_datetime, UNIX_MILLISECONDS_INTEGER_DATETIME_PARSING
 
 
 LOGGER = singer.get_logger()
@@ -49,6 +50,12 @@ def transform_event_times(record, project_timezone):
     # 'normalize' accounts for daylight savings time
     new_time_utc_str = strftime(timezone.normalize(new_time).astimezone(pytz.utc))
     new_record['time'] = new_time_utc_str
+
+    # Other timestamps need to be processed as wel
+    # Since singer.Transformer can only handle one date-time format
+    mp_processing_time_ms = int(record.get('mp_processing_time_ms'))
+    new_processing_time = _transform_datetime(mp_processing_time_ms, UNIX_MILLISECONDS_INTEGER_DATETIME_PARSING)
+    new_record['mp_processing_time_ms'] = new_processing_time
 
     return new_record
 


### PR DESCRIPTION
## Problem

Since the `time` field is determined by the client reporting the Mixpanel event, clients can post events out of order, esp. in relation to each other, e.g. due to being offline. When the `time` is used as bookmark this means that the bookmark can be moved ahead by one event in run 1 which causes a late arrived event with an earlier `time` to not be extracted in run 2. The `attribution_window` config can be used to address this but results in major duplication of the (majority of) events that arrive in time; generally at least 5 times with an `attribution_window` of 5 to account for that events are [allowed to be tracked up to 5 days late by Mixpanel](https://docs.mixpanel.com/docs/debugging/overview#delayed-ingestion).

## Proposed changes

1. `LOGGER.warn` -> `LOGGER.warning` to silence deprecation warnings
2. Refactor application of optional `export` stream parameters; `export_events` and `where`
3. Add back `event`, `time`, `distinct_id` as `key_properties` in addition to `mp_reserved_insert_id` since the latter is only unique within a specific combination of the former three. This could be important to avoid incorrect de-duplication of events (data loss) when used with some [taps that de-duplicates based on the `key_properties`](https://github.com/z3z1ma/target-bigquery/tree/5ee673f5dc33ccb0cce332aa9a2f6040114d12c4?tab=readme-ov-file#upsert-aka-merge).
4. Refactor to determine `where` query support by STREAM configuration rather than hard-coding to `export` stream, and enable it for `engage`, `funnels` and `cohort_members` where it is supported.
5. Include the `mp_processing_time_ms` field as an always de-nested field in the `export` stream schema, to be able to use it in the next step below.
6. Use `mp_processing_time_ms` as the `replication_keys` of the `export` stream since it is monotonically increasing as opposed to the `time` field as described in the [Problem](#problem)  section above. Use it both as the value to save as bookmark and to select events to export using the `where` query parameter. Note that the `time` based event selection using the `from_date` and `to_date` parameters is kept since they are required parameters, but modified to always be extended with the full `attribution_window` in all "date interval windows" (since actual selection is made with the `where` query) instead of only the initial one to start at least the `attribution_window` before the current/end date-time. Note that `mp_processing_time_ms` is queried in milliseconds since UTC epoch, while `time` (`from_date` and `to _date`) is queried using date in Mixpanel project timezone.
7. Fix the initial "date interval window" to not be truncated to full number of days before the current/end date-time when using the `mp_processing_time_ms` `where` query for event selection **or** when the window is larger than the `attribution_window`. Fixes potential missed/dropped events between tap runs in those scenarios.

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions